### PR TITLE
fix: typos, imports, types

### DIFF
--- a/components/account_management/UserAvatar.vue
+++ b/components/account_management/UserAvatar.vue
@@ -13,7 +13,7 @@
     'https://cdn.libretexts.net/DefaultImages/avatar.png';
   const props = withDefaults(
     defineProps<{
-      src: string;
+      src: string | undefined;
       width: number;
     }>(),
     {

--- a/components/layout/AppSwitcher.vue
+++ b/components/layout/AppSwitcher.vue
@@ -12,7 +12,7 @@
   >
   
     <FontAwesomeIcon
-      icon="fa-solid fa-rocket"
+      :icon="faRocket"
       class="text-primary rounded-md"
       size="2x"
     />
@@ -79,6 +79,7 @@
 <script lang="ts" setup>
   import { ref } from 'vue';
   import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+  import { faRocket } from '@fortawesome/free-solid-svg-icons';
   import { Application } from '@server/types/applications';
   import { usePageContext } from '@renderer/usePageContext';
   import { getUserAppsAndLibraries } from '@renderer/utils/apps';

--- a/components/layout/LibreOneHeader.vue
+++ b/components/layout/LibreOneHeader.vue
@@ -66,7 +66,7 @@
             :class="$props.authorized ? 'text-gray-500' : 'text-black'"
           >
             <FontAwesomeIcon
-              icon="right-from-bracket"
+              :icon="faRightFromBracket"
               class="w-6 h-6 mt-1.5"
               v-if="$props.authorized"
             />
@@ -77,7 +77,7 @@
             @click="menuOpen = !menuOpen"
             aria-label="Open Navigation Menu"
             :class="menuOpen ? 'motion-safe:-rotate-90' : ''"
-            icon="fa-solid fa-bars"
+            :icon="faBars"
             size="lg"
           />
         </div>
@@ -143,6 +143,7 @@
 <script lang="ts" setup>
   import { ref, computed } from 'vue';
   import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+  import { faRightFromBracket, faBars } from '@fortawesome/free-solid-svg-icons';
   import AppSwitcher from './AppSwitcher.vue';
   import { usePageContext } from '@renderer/usePageContext';
   import UserAvatar from '../account_management/UserAvatar.vue';

--- a/pages/passwordrecovery/complete/+onBeforeRender.ts
+++ b/pages/passwordrecovery/complete/+onBeforeRender.ts
@@ -1,5 +1,5 @@
 import { buildLocalizedServerRedirectURL } from '@renderer/helpers';
-import type { PageContextServer } from '@renderer/types';
+import type { PageContextServer } from "vike/types";
 
 /**
  * Reads search parameters provided in the URL and transforms them to component props. Redirects

--- a/renderer/app.ts
+++ b/renderer/app.ts
@@ -43,6 +43,7 @@ export function createApp(pageContext: PageContext) {
   const dataRef = shallowRef(pageContext.data);
   const pageRef = shallowRef(pageContext.Page);
 
+  // @ts-ignore
   const RootComponent = () => h(BaseLayout, {}, () => h(pageRef.value, pageContextRef.value.pageProps));
   const app = createSSRApp(RootComponent);
   setPageContext(app, pageContextRef);

--- a/server/controllers/VerificationRequestController.ts
+++ b/server/controllers/VerificationRequestController.ts
@@ -308,7 +308,7 @@ export class VerificationRequestController {
       return foundVerifyReq;
     });
 
-    if (prevStatus === 'needs_change' && status === 'open') {
+    if (prevStatus === 'needs_change' && props.status === "open") {
       await this.sendAdminUpdatedRequestNotification();
     }
     return updatedReq;

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,7 +50,7 @@ const clientRouter = express.Router();
 clientRouter.route('*').get(async (req: Request, res: Response, next: NextFunction) => {
   const userController = new UserController();
   const { expired, sessionInvalid, isAuthenticated, userUUID } = await AuthController.verifyClientAuthentication(req);
-  let user;
+  let user: Record<string, string> | null = null;
   if (isAuthenticated && userUUID) {
     user = await userController.getUserInternal(userUUID, true);
   }
@@ -84,7 +84,7 @@ clientRouter.route('*').get(async (req: Request, res: Response, next: NextFuncti
     urlOriginal: req.originalUrl,
     productionURL: getProductionURL(),
     ...(user && { user }),
-  };
+  } as PageContext; // TODO: use `@universal-middleware/core` types
 
   const { httpResponse, redirectTo } = await renderPage(pageContextInit);
   const { statusCode, headers } = httpResponse || {};

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -56,7 +56,7 @@ export async function verifyBasicAuthorization(req: Request, res: Response, next
     if (authParts.length < 2) {
       return errors.badRequest(res);
     }
-    const { isAuthorized, permissions } = await APIUserController.verifyAPIUserAuth(authParts[0], authParts[1], req.ip);
+    const { isAuthorized, permissions } = await APIUserController.verifyAPIUserAuth(authParts[0], authParts[1], req.ip || '');
     if (!isAuthorized) {
       return errors.unauthorized(res, undefined, 'LibreOne API');
     }

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -37,6 +37,7 @@ import { ApplicationLicense } from './ApplicationLicense';
 import { ApplicationLicenseEntitlement } from './ApplicationLicenseEntitlement';
 import { UserLicenseEntitlement } from './UserLicenseEntitlement';
 import { AccessCode } from './AccessCode';
+import type { Transaction } from 'sequelize';
 
 const env = (process.env.NODE_ENV || 'test').toUpperCase();
 
@@ -132,7 +133,7 @@ async function createDefaultTimeZones() {
  * Creates default Licenses where necessary.
  */
 async function createDefaultLicenses() {
-  let transaction;
+  let transaction: Transaction | undefined;
   try {
     console.log('[DB] Creating default licenses...');
     const existing = await License.findAll();

--- a/server/tests/auth.spec.ts
+++ b/server/tests/auth.spec.ts
@@ -98,8 +98,8 @@ describe('Authentication and Authorization', async () => {
       expect(response.status).to.equal(200);
       expect(response.body?.data).to.deep.equal({ uuid: user1.uuid });
       expect(response.get('Set-Cookie')).to.be.an('array').with.length(2);
-      expect(response.get('Set-Cookie')[0]).to.contain('one_access=');
-      expect(response.get('Set-Cookie')[1]).to.contain('one_signed=');
+      expect(response.get('Set-Cookie')?.[0]).to.contain('one_access=');
+      expect(response.get('Set-Cookie')?.[1]).to.contain('one_signed=');
       await user1.destroy();
     });
     it('should fail to verify with incorrect code', async () => {
@@ -193,8 +193,8 @@ describe('Authentication and Authorization', async () => {
         .set('Cookie', await createSessionCookiesForTest(user1.uuid));
       expect(response.status).to.equal(302);
       expect(response.get('Set-Cookie')).to.be.an('array').with.length(2);
-      expect(response.get('Set-Cookie')[0]).to.contain('one_access=;'); // cleared
-      expect(response.get('Set-Cookie')[1]).to.contain('one_signed=;'); // cleared
+      expect(response.get('Set-Cookie')?.[0]).to.contain('one_access=;'); // cleared
+      expect(response.get('Set-Cookie')?.[1]).to.contain('one_signed=;'); // cleared
 
       await user1.destroy();
     });

--- a/server/tests/test-helpers.ts
+++ b/server/tests/test-helpers.ts
@@ -7,7 +7,7 @@ import { AuthController } from '../controllers/AuthController';
  * @returns Cookie strings for use in superagent requests.
  */
 export async function createSessionCookiesForTest(uuid: string): Promise<[string, string]> {
-  const sessionJWT = await AuthController.createSessionJWT(uuid);
+  const sessionJWT = await AuthController.createSessionJWT(uuid, "");
   const [access, signed] = AuthController.splitSessionJWT(sessionJWT);
   return [`one_access=${access}`, `one_signed=${signed}`];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@server/*": ["./server/*"],
       "@renderer/*": ["./renderer/*"],
-      "@locales/*": ["./locales/*"]
+      "@locales/*": ["./locales/*"],
+      "@components/*": ["./components/*"]
     }
   },
   "ts-node": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,11 +25,11 @@ const config: UserConfig = {
   },
   optimizeDeps: {
     include: [
-      "@fontawesome/fontawesome-svg-core",
+      "@fortawesome/fontawesome-svg-core",
       "@fortawesome/free-solid-svg-icons",
       "@fortawesome/vue-fontawesome",
-    ]
-  }
+    ],
+  },
 };
 
 export default config;

--- a/vue.d.ts
+++ b/vue.d.ts
@@ -1,4 +1,4 @@
 declare module '*.vue' {
-  const Component: any;
-  export default Component;
+  import Vue from "vue";
+  export default Vue;
 }


### PR DESCRIPTION
Hey, love what you guys are doing! Just thought I'd pop in and contribute some fixes:

- The fontawesome icons had warnings (such as `Could not find one or more icon(s) { prefix: 'fas', iconName: 'rocket' } {}`) so I used the imports instead
- Fixed the `vue.d.ts` shim file to enable type checking Vue components
- Fixed the `tsconfig.json` import alias path for `@components`
- Fixed a typo (`@fontawesome` -> `@fortawesome`) in `vite.config.ts`
- Fixed an undefined var in the `updateVerificationRequestByUser` API route

Also, would you like a docker-compose config for running mysql + `apereo/cas` with seeded users / libraries, or is this just running off some local/remote setup?